### PR TITLE
Fix C++ initialization order errors

### DIFF
--- a/components/twc-controller/twc_protocol.cpp
+++ b/components/twc-controller/twc_protocol.cpp
@@ -29,14 +29,14 @@ namespace esphome {
 
         TeslaController::TeslaController(uart::UARTComponent* serial, TeslaControllerIO *io, uint16_t twcid, GPIOPin *flow_control_pin, int passive_mode) :
             serial_(serial),
-            controller_io_(io),
             flow_control_pin_(flow_control_pin),
-            max_current_(0),
-            min_current_(0),
-            stopstart_delay_(0),
+            controller_io_(io),
             num_connected_chargers_(0),
             twcid_(twcid),
             sign_(0x77),
+            max_current_(0),
+            min_current_(0),
+            stopstart_delay_(0),
             debug_(false),
             passive_mode_(passive_mode)
         {
@@ -665,9 +665,9 @@ namespace esphome {
                     break;
             }
 
-            if (changed & (strlen((const char*)vin) == 17)) {
+            if (changed && (strlen((const char*)vin) == 17)) {
                 controller_io_->writeChargerConnectedVin(vin_data->twcid, std::string((char *)vin));
-            } else if (changed & strlen((const char*)vin) == 0) {
+            } else if (changed && strlen((const char*)vin) == 0) {
                 controller_io_->writeChargerConnectedVin(vin_data->twcid, "0");
             }
 


### PR DESCRIPTION
The order of class members in the class declaration is the order they are initialized, regardless of the order in the constructor's initializer list. Some compilers / flag combinations will error if the initializer list does not match as it implies the wrong order, including the one used by the esp-idf framework when compiling for esp32-c3.

Align the initializer list in TeslaController() to match the declaration order in the header, and a few other warning.s