### PR TITLE
Implement START_CHARGING / STOP_CHARGING commands

### DIFF
--- a/components/twc-controller/twc_protocol.cpp
+++ b/components/twc-controller/twc_protocol.cpp
@@ -88,6 +88,14 @@ namespace esphome {
                         twc->SendHeartbeat(twc->chargers[i]->twcid);
                         if (twc->current_changed_ == true) { twc->current_changed_ = false; };
 
+                        // Re-assert STOP while in stop-state: if we want 0 A but
+                        // the vehicle is still drawing (e.g. it drifted back up
+                        // after fast cycling, with no fresh 0-transition), keep
+                        // sending STOP_CHARGING so the session is reliably halted.
+                        if (twc->available_current_ == 0 && twc->IsCharging()) {
+                            twc->StopCharging(twc->chargers[i]->twcid);
+                        }
+
                         vTaskDelay(500+random(50,100)/portTICK_PERIOD_MS);
 
                         switch (commandNumber) {

--- a/components/twc-controller/twc_protocol.cpp
+++ b/components/twc-controller/twc_protocol.cpp
@@ -237,18 +237,32 @@ namespace esphome {
             if (available_current_ != current) {
                 ESP_LOGD(TAG, "Received current change message, new current %d\r\n", current);
                 current_changed_ = true;
+
+                bool was_zero = (available_current_ == 0);
+
+                // Use the protocol's explicit charge commands on the zero
+                // boundary. The heartbeat keeps flowing in both cases (the
+                // link is never cut), so a stopped session can be resumed.
+                if (current == 0) {
+                    for (uint8_t i = 0; i < this->ChargersConnected(); i++) {
+                        for (uint8_t r = 0; r < 3; r++) {
+                            this->StopCharging(this->chargers[i]->twcid);
+                            delay(100);
+                        }
+                    }
+                } else if (was_zero) {
+                    for (uint8_t i = 0; i < this->ChargersConnected(); i++) {
+                        for (uint8_t r = 0; r < 3; r++) {
+                            this->StartCharging(this->chargers[i]->twcid);
+                            delay(100);
+                        }
+                    }
+                }
             }
 
-            // If the available current is higher than the maximum for our charger,
-            // clamp it to the maximum
-            available_current_ = clamp(current, min_current_, max_current_);
-            /*if (current <= MAX_CURRENT & current >= MIN_CURRENT) {
-                available_current_ = current;
-            } else if (current > MAX_CURRENT) {
-                available_current_ = MAX_CURRENT;
-            } else if (current < MIN_CURRENT) {
-                available_current_ = MIN_CURRENT;
-            }*/
+            // A current of 0 means "stop": let it pass through so the heartbeat
+            // advertises 0 A. Any other value is clamped to the charger range.
+            available_current_ = (current == 0) ? 0 : clamp(current, min_current_, max_current_);
         }
 
         void TeslaController::SendPresence(bool presence2) {
@@ -321,6 +335,20 @@ namespace esphome {
             }
             packet.checksum = CalculateChecksum((uint8_t*)&packet, sizeof(packet));
             SendData((uint8_t*)&packet, sizeof(packet));
+        }
+
+        // Protocol-native commands (0xFC range, no response from the secondary):
+        // ask the charger itself to start/stop the session. Distinct from
+        // simply advertising a 0 A current limit, which some vehicles keep
+        // drawing a minimum against.
+        void TeslaController::StopCharging(uint16_t twcid) {
+            ESP_LOGD(TAG, "Sending STOP_CHARGING (0xFCB2) to %04x", twcid);
+            SendCommand(STOP_CHARGING, twcid);
+        }
+
+        void TeslaController::StartCharging(uint16_t twcid) {
+            ESP_LOGD(TAG, "Sending START_CHARGING (0xFCB1) to %04x", twcid);
+            SendCommand(START_CHARGING, twcid);
         }
 
         uint8_t TeslaController::CalculateChecksum(uint8_t *buffer, size_t length) {


### PR DESCRIPTION
## What

`StopCharging()` and `StartCharging()` were declared in `twc_protocol.h` but never implemented. This PR wires them to the protocol's `START_CHARGING` (0xFCB1) / `STOP_CHARGING` (0xFCB2) commands via `SendCommand`, and calls them from `SetCurrent()` on the zero-current boundary:

- current set to **0** → send `STOP_CHARGING`
- current set back to **non-zero** (from 0) → send `START_CHARGING`

A current of 0 is now passed through to the heartbeat (advertising 0 A) instead of being clamped up to `min_current`. Heartbeats keep flowing in both cases, so the link is never cut and a stopped session can be resumed by raising the current again.

## Why

Advertising a 0 A current limit alone does not reliably stop charging on some vehicles — they keep drawing a minimum current. The explicit protocol commands stop the session at the charger.

## Testing

Tested on a Gen2 Wall Connector with a Fiat 500e:
- Setting current to 0 drops the car to 0 W cleanly (no residual minimum draw).
- Raising the current again resumes charging within the same session (no unplug/replug needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)