### PR TITLE
Discard non-ASCII serial/VIN fields instead of publishing them

### DIFF
--- a/components/twc-controller/twc_connector.h
+++ b/components/twc-controller/twc_connector.h
@@ -36,7 +36,7 @@ namespace esphome {
                 uint8_t state;
                 uint8_t firmware_version[4];
                 
-                uint8_t serial_number[11];
+                uint8_t serial_number[12];  // 11 chars + NUL
                 
                 uint32_t total_kwh;
                 uint16_t phase1_voltage;

--- a/components/twc-controller/twc_protocol.cpp
+++ b/components/twc-controller/twc_protocol.cpp
@@ -373,14 +373,36 @@ namespace esphome {
             }
         }
 
+        // Convert a raw, possibly non-NUL-terminated protocol field into a printable
+        // ASCII string. Returns false as soon as the field contains anything that is
+        // not printable ASCII, so a corrupt RS485 frame never reaches the API as an
+        // invalid UTF-8 text sensor state. aioesphomeapi rejects such a frame and
+        // drops the connection, after which the retained state is resent on every
+        // reconnect, leaving the client in a permanent reconnect loop.
+        static bool SanitizeAsciiField(const uint8_t *data, size_t max_len, std::string &out) {
+            out.clear();
+            for (size_t i = 0; i < max_len; i++) {
+                if (data[i] == '\0') break;
+                if (data[i] < 0x20 || data[i] > 0x7E) return false;
+                out.push_back((char)data[i]);
+            }
+            return !out.empty();
+        }
+
         void TeslaController::DecodeSerialNumber(EXTENDED_RESP_PACKET_T *serial) {
             SERIAL_PAYLOAD_T *serial_payload = (SERIAL_PAYLOAD_T *)serial->payload;
 
             TeslaConnector *c = GetConnector(serial->twcid);
 
-            if (strcmp((const char*)c->serial_number, (const char*)serial_payload->serial) != 0) {
-                strcpy((char *)&c->serial_number, (const char*)&serial_payload->serial);
-                controller_io_->writeChargerSerial(serial->twcid, std::string((char*)&c->serial_number));
+            std::string serial_str;
+            if (!SanitizeAsciiField(serial_payload->serial, sizeof(serial_payload->serial), serial_str)) {
+                ESP_LOGW(TAG, "Discarding corrupt serial number packet for %04x", serial->twcid);
+                return;
+            }
+
+            if (strncmp((const char*)c->serial_number, serial_str.c_str(), sizeof(c->serial_number)) != 0) {
+                snprintf((char *)c->serial_number, sizeof(c->serial_number), "%s", serial_str.c_str());
+                controller_io_->writeChargerSerial(serial->twcid, serial_str);
             }
 
 
@@ -665,10 +687,15 @@ namespace esphome {
                     break;
             }
 
-            if (changed && (strlen((const char*)vin) == 17)) {
-                controller_io_->writeChargerConnectedVin(vin_data->twcid, std::string((char *)vin));
-            } else if (changed && strlen((const char*)vin) == 0) {
-                controller_io_->writeChargerConnectedVin(vin_data->twcid, "0");
+            if (changed) {
+                std::string vin_str;
+                if (SanitizeAsciiField(vin, 17, vin_str) && vin_str.length() == 17) {
+                    controller_io_->writeChargerConnectedVin(vin_data->twcid, vin_str);
+                } else if (strlen((const char*)vin) == 0) {
+                    controller_io_->writeChargerConnectedVin(vin_data->twcid, "0");
+                } else {
+                    ESP_LOGW(TAG, "Discarding corrupt VIN for %04x", vin_data->twcid);
+                }
             }
 
             if (debug_) {


### PR DESCRIPTION
A corrupt RS485 frame can permanently wedge the Home Assistant API connection, with no self-recovery.

## The problem

`SERIAL_PAYLOAD_T.serial` (11 bytes) and the VIN are raw, non-NUL-terminated protocol fields. `DecodeSerialNumber()` and `DecodeVin()` published them straight to the text sensors. If such a frame is corrupt, the resulting state is not valid UTF-8. `aioesphomeapi` then rejects the `TextSensorStateResponse` and drops the connection:

```
ERROR [aioesphomeapi.connection] twc @ 192.168.x.x: Invalid protobuf message:
type=TextSensorStateResponse len=18 data=b"\r\x11\xaf:{\x12\x0b\xb3a\xf1\x14\x84 \xd9q3f\xcb"
```

Because the bad state is retained on the device, it is resent on the next connect, which fails identically. On my setup this ran at roughly three reconnects per second for two days without ever recovering, filling the HA log and the recorder database, and it only stopped after a reflash. The identical payload in every log line shows this is a stuck state rather than line noise.

## The fix

`SanitizeAsciiField()` accepts a field only if it is entirely printable ASCII, and is used for both the serial number and the VIN. A corrupt frame is logged and discarded, so the API only ever sees valid text.

Also fixes a buffer overflow in the same path: an unterminated 11-byte `serial` was `strcpy`d into an 11-byte `serial_number`, reading and writing past the end of both. The copy is now bounded with `snprintf`, and the destination holds 11 characters plus NUL.

## Testing

Built with ESPHome 2026.5.2 and flashed over OTA to a Gen2 TWC. Before the patch, the reconnect loop was permanent. After, zero protocol errors and all entities stable. My charger turns out to send a serial that is genuinely not ASCII on every poll, so the new warning fires roughly every ten seconds and the serial sensor stays unknown, while every other entity works normally. That is the intended degradation: one unparsable field no longer takes the whole connection down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)